### PR TITLE
Add bin/setup for call centre applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ The browser tests use these technologies:
 | Service | Default host and port |
 |---|---|
 | `postgresql` | localhost:5432 |
-| `rabbitmq` | localhost:5672 and localhost:15672 for the management interface|
+| `rabbitmq` | localhost:5672<br/>localhost:15672 for the management interface|
 
 | Application | Default host and port |
 |---|---|
 | `cla_public` | localhost:5000 |
-| `cla_frontend` | ??? |
+| `cla_frontend` | localhost:8001<br/>localhost:8005 for websockets |
 | `cla_backend` | localhost:8000 |
 | `laalaa` | ??? |
 | `fala` | ??? |
@@ -123,6 +123,3 @@ Here's a very high level view of things we want to achieve.
 
 ### Later
 Nothing yet
-
-
-

--- a/bin/setup
+++ b/bin/setup
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 docker-compose run start_services
 docker-compose run start_applications
+echo "🎉 All up!"

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+docker-compose run start_services
+docker-compose run start_applications

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,27 +1,58 @@
-version: '3'
+version: '3.2'
 services:
-  django:
+  start_services:
+    image: jwilder/dockerize
+    command: "-wait tcp://db:5432 -timeout 30s"
+    depends_on:
+      - db
+  start_applications:
+    image: jwilder/dockerize
+    command: "-wait tcp://cla_frontend:80 -wait tcp://cla_frontend:8005 -wait tcp://cla_backend:80 -timeout 180s"
+    depends_on:
+      - cla_frontend
+      - cla_backend
+
+  # services
+  db:
+    image: postgres:9.6-alpine
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: cla_backend
+
+  # applications
+  cla_frontend:
     build: https://github.com/ministryofjustice/cla_frontend.git#develop
     ports:
-      - "8001:80"
-      - "8005:8005"
+      - target: 80
+        published: 8001
+        protocol: tcp
+        mode: host
+      - target: 8005
+        published: 8005
+        protocol: tcp
+        mode: host
     environment:
       ENV: local
       DEBUG: "True"
       SECRET_KEY: CHANGE_ME
-      BACKEND_BASE_URI: http://clabackend
+      BACKEND_BASE_URI: http://cla_backend:80
       CALL_CENTRE_CLIENT_ID: b4b9220ffcb11ebfdab1
       CALL_CENTRE_SECRET_ID: 2df71313bdd38a2e1b815015e1b14387e7681d41
       CLA_PROVIDER_CLIENT_ID: 59657ed22d980251cdd3
       CALL_PROVIDER_SECRET_ID: 0494287c65bdf61d29f0eeed467ec8e090f0d80f
       SOCKETIO_SERVER_URL: /socket.io
     depends_on:
-      - clabackend
-
-  clabackend:
+      - cla_backend
+  cla_backend:
     build: https://github.com/ministryofjustice/cla_backend.git#develop
     ports:
-      - "8000:80"
+      - target: 80
+        published: 8000
+        protocol: tcp
+        mode: host
     environment:
       ENV: local
       DEBUG: "True"
@@ -37,15 +68,3 @@ services:
       ALLOWED_HOSTS: "*"
     depends_on:
       - db
-
-  db:
-    image: postgres
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: cla_backend
-
-  test:
-    build: .
-    depends_on:
-      - django

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
 
   # services
   db:
-    image: postgres:9.6-alpine
+    image: postgres:9.4-alpine
     ports:
       - '5432:5432'
     environment:


### PR DESCRIPTION
It uses https://github.com/jwilder/dockerize as separate "tasks" and docker compose's `depends_on` feature to ensure that all dependencies are started and respond on their ports.

Using this method, the setup scripts becomes:

```bash
#!/bin/bash -e
docker-compose run start_services
docker-compose run start_applications
echo "🎉 All up!"
```

💭 This approach leaves room to insert "pre-deployment" steps (creating databases, migrations, seeds, etc.) between the two start steps.

💄 I have also opted to use the [long `ports` syntax](https://docs.docker.com/compose/compose-file/#long-syntax-1) because I always forget what is where in the short one. 😊 On the flip side, it requires Docker Engine 17.04.0+.