### PR TITLE
Add code owners to the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*      @ministryofjustice/laa-get-access


### PR DESCRIPTION
This pull request sets up @ministryofjustice/laa-get-access developers as the code owners of this repository.