### PR TITLE
Pull docker images from Amazon ECR registry in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The browser tests use these technologies:
 #### Make sure you're logged into Amazon ECR registry with get-login
 
 1. Install AWS CLI
-1. Use `aws configure` to configure your AWS Access Key ID and AWS Secret Access Key, and set the default region name to `eu-west-2`.
+1. Use `aws configure` to configure your AWS Access Key ID and AWS Secret Access Key, and set the default region name to `eu-west-1`.
 1. Run `aws ecr get-login --no-include-email`
 1. Copy and paste the resulting docker login command into a terminal to authenticate your Docker CLI to the registry. This command provides an authorization token that is valid for the specified registry for 12 hours.
 1. Run `aws ecr describe-repositories`. You should see a list of ECR repositories.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ The browser tests use these technologies:
 
 ### Running tests locally
 
+#### Make sure you're logged into Amazon ECR registry with get-login
+
+1. Install AWS CLI
+1. Use `aws configure` to configure your AWS Access Key ID and AWS Secret Access Key, and set the default region name to `eu-west-2`.
+1. Run `aws ecr get-login --no-include-email`
+1. Copy and paste the resulting docker login command into a terminal to authenticate your Docker CLI to the registry. This command provides an authorization token that is valid for the specified registry for 12 hours.
+1. Run `aws ecr describe-repositories`. You should see a list of ECR repositories.
+
+#### Run the scripts
+
 ```
 $ bin/setup
 $ bin/run

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,6 @@
 #!/bin/bash -e
+export ECR_ENDPOINT=627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access
+
 docker-compose run start_services
 docker-compose run start_applications
 echo "🎉 All up!"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
     depends_on:
       - cla_backend
   cla_backend:
-    build: https://github.com/ministryofjustice/cla_backend.git#develop
+    image: ${ECR_ENDPOINT}/cla_backend:develop
     ports:
       - target: 80
         published: 8000


### PR DESCRIPTION
Currently, we have two ECR repositories:

- get-access/cla_backend
- get-access/cla_public

This pull request sets up `cla_backend`. `cla_public` is not configured in `docker-compose.yml` yet. And `cla_frontend` does not yet have Circle CI jobs set up for build and push to ECR.