### PR TITLE
Run the call centre tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ The browser tests use these technologies:
 1. Copy and paste the resulting docker login command into a terminal to authenticate your Docker CLI to the registry. This command provides an authorization token that is valid for the specified registry for 12 hours.
 1. Run `aws ecr describe-repositories`. You should see a list of ECR repositories.
 
-#### Run the scripts
+#### Run the tests
+The following command will (1) start services and applications, (2) run the tests and (3) stop the services and applications.
 
 ```
-$ bin/setup
-$ bin/run
+$ bin/setup && bin/run_tests && bin/stop
 ```
 
 ### Running tests against staging

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+docker-compose run test_call_centre
+echo "🎉 Tests finished!"

--- a/bin/stop
+++ b/bin/stop
@@ -1,3 +1,3 @@
 #!/bin/bash -e
-docker-compose stop
+docker-compose down
 echo "🎉 All services and apps stopped!"

--- a/bin/stop
+++ b/bin/stop
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+docker-compose stop
+echo "🎉 All services and apps stopped!"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
 
   # applications
   cla_public:
-    image: ${ECR_ENDPOINT}/cla_public:develop
+    image: 627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access/cla_public:develop
     ports:
       - target: 80
         published: 5000
@@ -75,7 +75,7 @@ services:
     depends_on:
       - cla_backend
   cla_backend:
-    image: ${ECR_ENDPOINT}/cla_backend:develop
+    image: 627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access/cla_backend:develop
     ports:
       - target: 80
         published: 8000
@@ -96,3 +96,7 @@ services:
       ALLOWED_HOSTS: "*"
     depends_on:
       - db
+
+  test_call_centre:
+    build:
+      context: tests/call-centre

--- a/tests/call-centre/protractor.conf.js
+++ b/tests/call-centre/protractor.conf.js
@@ -8,7 +8,7 @@ exports.config = {
       binary: puppeteer.executablePath()
     }
   },
-  baseUrl: "http://django/",
+  baseUrl: "http://cla_frontend/",
   directConnect: true,
   framework: "jasmine",
   jasmineNodeOpts: {


### PR DESCRIPTION
## What does this pull request do?

It runs the call centre tests. Well, the ones that are actually passing 😕. I've also added an instruction to the README that says how to run the tests:

```
$ bin/setup && bin/run_tests && bin/stop
```

## Any other changes which would benefit highlighting?

### Flaky test
One of the tests might be flaky. @aliuk2012 is working on the tests, which currently reside in https://github.com/ministryofjustice/cla_frontend/pull/620. 
