### PR TITLE
Use master tag in docker-compose where appropriate

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
     depends_on:
       - cla_backend
   cla_backend:
-    image: 627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access/cla_backend:develop
+    image: 627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access/cla_backend:master
     ports:
       - target: 80
         published: 8000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
 
   # applications
   cla_public:
-    image: 627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access/cla_public:develop
+    image: 627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access/cla_public:master
     ports:
       - target: 80
         published: 5000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
     depends_on:
       - cla_backend
   cla_backend:
-    image: 627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access/cla_backend:master
+    image: 627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access/cla_backend:develop
     ports:
       - target: 80
         published: 8000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
 
   # applications
   cla_public:
-    image: 627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access/cla_public:master
+    image: 627373361525.dkr.ecr.eu-west-1.amazonaws.com/get-access/cla_public:master.latest
     ports:
       - target: 80
         published: 5000


### PR DESCRIPTION
## What does this pull request do?

It switches from `develop` to `master.latest` tag when pulling down from AWS ECR for:

- `cla_public`

## Any other changes that would benefit highlighting?

`cla_backend` does not have an image tagged `master.latest` in ECR.
`cla_frontend` does not have an image in ECR yet.