### PR TITLE
LGA-21 Add front end tests postcode redaction cla public

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,48 @@ $ bin/setup && bin/run_tests_in_docker && bin/stop
 ```
 
 #### Run the tests on local machine
-To run the Check Legal Aid tests locally, run the following commands:
+First - run cla_backend and cla_public locally (copy the cla_public url, adding a '/start' at the end to ensure it is running locally)
 
+To run the Check Legal Aid tests locally, run the following commands:
 ```
 cd tests/check-legal-aid
 npm install
 npm test
 ```
+
+### Trouble shooting for local machine.
+Make sure you are in:
+```buildoutcfg
+tests/check-legal-aid
+```
+#####- Failing test due to an incorrect URL being generated. 
+
+   
+Go to:     
+    ```
+    tests/check-legal-aid/nightwatch.conf.js
+    ```
+
+And change:
+    ```
+    var baseUrl = process.env.CLA_PUBLIC_URL || localhost;
+    ```
+     
+With: 
+    ```
+     var baseUrl = process.env.CLA_PUBLIC_URL || "http://127.0.0.1:5000";
+    ```
+
+#####- If you receive the following error message start the chrome driver manually:
+```
+ Error retrieving a new session from the selenium server   
+```
+ - open a new terminal and paste the following:
+    
+```buildoutcfg
+./node_modules/chromedriver/bin/chromedriver 
+```
+
 
 ### Running tests against staging
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,29 @@ npm install
 npm test
 ```
 
+#### Run single test on local machine
+To run a single test on your local machine go to:
+```tests/check-legal-aid/package.json```
+Inside 'scripts' create a new test name with a path to your test.
+```
+{
+  "name": "laa-cla-e2e-tests",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "find test/specs/ -type f -exec nightwatch {} +",
+    "name-of-new-test": "nightwatch test/specs/face-to-face-page.js",
+    "test-docker": "find test/specs/ -type f -exec nightwatch --verbose {} +"
+  },
+```
+
+To run your test in the terminal run:
+```buildoutcfg
+npm run name-of-new-test
+```
+
 ### Trouble shooting for local machine.
+Check you are running cla_back end and cla_public locally
 Make sure you are in:
 ```buildoutcfg
 tests/check-legal-aid
@@ -130,7 +152,13 @@ With:
 ```
  Error retrieving a new session from the selenium server   
 ```
- - open a new terminal and paste the following:
+ - open a new terminal
+ - make sure you are inside: 
+ ```buildoutcfg
+tests/check-legal-aid
+```
+  
+- paste the following
     
 ```buildoutcfg
 ./node_modules/chromedriver/bin/chromedriver 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,14 @@ services:
       HOST_NAME: "0.0.0.0"
       SECRET_KEY: CHANGE_ME
       BACKEND_BASE_URI: http://cla-backend:80
+      ZENDESK_API_USERNAME: ""
+      ZENDESK_API_TOKEN: ""
+      SMTP_HOST: ""
+      SMTP_USER: ""
+      SMTP_PASSWORD: ""
+      RAVEN_CONFIG_DSN: ""
+      RAVEN_CONFIG_SITE: ""
+      LAALAA_API_HOST: "https://prod.laalaa.dsd.io"
     depends_on:
       - cla_backend
     external_links:

--- a/tests/check-legal-aid/test/specs/face-to-face-page.js
+++ b/tests/check-legal-aid/test/specs/face-to-face-page.js
@@ -6,8 +6,7 @@ module.exports = {
   "Start page": function(client) {
     client.startService();
   },
-
-  "@disabled": true,
+  "@disabled": false,
   "Scope diagnosis": function(client) {
     client.scopeDiagnosis(constants.SCOPE_PATHS.clinnegFaceToFace);
   },
@@ -26,8 +25,8 @@ module.exports = {
 
   "Find legal adviser search": function(client) {
     client
-      .setValue('input[name="postcode"]', "w22dd", function() {
-        console.log("     • Enter postcode `w22dd`");
+      .setValue('input[name="postcode"]', "SW1A 1AA", function() {
+        console.log("     • Enter postcode `SW1A 1AA`");
       })
       .conditionalFormSubmit(true)
       .assert.urlContains("/scope/refer/legal-adviser", "    - Page is ready")
@@ -46,6 +45,19 @@ module.exports = {
         constants.SCOPE_PATHS.clinnegFaceToFace.title.toUpperCase(),
         "    - Filter contains category name"
       );
+
+
+     client.executeAsync(function(done) {
+         ga(function(tracker) {
+           done(tracker.get('location'))
+         });
+      }, function(result) {
+          ".google-analytics-postcode-redaction",
+            client.assert.equal(
+            result.value, 'http://127.0.0.1:5000/scope/refer/legal-adviser?category=clinneg');
+          "    - Google Analytics postcode redaction"
+      });
+
 
     client.end();
   },

--- a/tests/check-legal-aid/test/specs/face-to-face-page.js
+++ b/tests/check-legal-aid/test/specs/face-to-face-page.js
@@ -54,8 +54,9 @@ module.exports = {
       }, function(result) {
           ".google-analytics-postcode-redaction",
             client.assert.equal(
-            result.value, 'http://127.0.0.1:5000/scope/refer/legal-adviser?category=clinneg');
-          "    - Google Analytics postcode redaction"
+            result.value, 'http://127.0.0.1:5000/scope/refer/legal-adviser?category=clinneg',
+            "    - Google Analytics postcode redaction"
+         );
       });
 
 

--- a/tests/check-legal-aid/test/specs/face-to-face-page.js
+++ b/tests/check-legal-aid/test/specs/face-to-face-page.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var constants = require("../modules/constants");
+var nightwatch = require("../../nightwatch.conf")
 
 module.exports = {
   "Start page": function(client) {
@@ -52,14 +53,9 @@ module.exports = {
            done(tracker.get('location'))
          });
       }, function(result) {
-          ".google-analytics-postcode-redaction",
-            client.assert.equal(
-            result.value, 'http://127.0.0.1:5000/scope/refer/legal-adviser?category=clinneg',
-            "    - Google Analytics postcode has been redacted"
-         );
+        var url = nightwatch.test_settings.default.globals.baseUrl + "/scope/refer/legal-adviser?category=clinneg";
+        client.assert.equal(result.value, url,"    - Google Analytics postcode has been redacted");
       });
-
-
     client.end();
   },
 

--- a/tests/check-legal-aid/test/specs/face-to-face-page.js
+++ b/tests/check-legal-aid/test/specs/face-to-face-page.js
@@ -55,7 +55,7 @@ module.exports = {
           ".google-analytics-postcode-redaction",
             client.assert.equal(
             result.value, 'http://127.0.0.1:5000/scope/refer/legal-adviser?category=clinneg',
-            "    - Google Analytics postcode redaction"
+            "    - Google Analytics postcode has been redacted"
          );
       });
 

--- a/tests/check-legal-aid/test/specs/property-page.js
+++ b/tests/check-legal-aid/test/specs/property-page.js
@@ -85,8 +85,18 @@ module.exports = {
     client
       .click(
         util.format('input[name="%s"][value="%s"]', "properties-0-is_rented", 0)
-      )
-      .conditionalFormSubmit(true);
+      );
+
+      // Sometimes if the element is not in view then selenium doesn't allow you to manipulate
+      // This makes sure the content start is in view as that's where the error message box appears
+      client
+        .execute(
+          'var mainContentElements = document.getElementsByClassName("main-content");' +
+          'mainContentElements[0].scrollIntoView(true);'
+        );
+
+      client.pause(500);
+      client.conditionalFormSubmit(true);
   },
 
   "Add/remove properties": function(client) {


### PR DESCRIPTION
## What does this pull request do?
[LGA-21 Add frontend tests for postcode redaction from google analytics - CLA public](https://dsdmoj.atlassian.net/browse/LGA-512)

- Inside the face-to-face-page end-to-end test an extra check has been included that ensures that the post code entered into the search bar is redacted from the url before it is sent to Google Analytics. 

- The README has also been edited to include extra information on running these tests, both how to run an individual test and trouble shooting if your tests fail to run. 

## Any other changes that would benefit highlighting?

I had to add the required environment variables for the cla_public docker-compose service otherwise the application will not boot, that was put in https://github.com/ministryofjustice/cla_public/pull/835