### PR TITLE
LGA-621: Add nightly build to the end-to-end test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -26,3 +26,15 @@ jobs:
       - run:
           name: Clean up running containers
           command: bin/stop
+workflows:
+  version: 2
+  run-tests:
+    jobs: [build]
+  nightly:
+    jobs: [build]
+    triggers:
+      - schedule:
+          cron: "0 1 * * *"
+          filters:
+            branches:
+              only: [master]


### PR DESCRIPTION
## What does this pull request do?

Configures the end-to-end test suite to run every night at 1 am (UTC)

## Why make these changes?

Since these tests are not currently triggered on application changes, running the suite every night would give us

- earlier discovery for application change failures
- earlier discovery for "framework" failures, for example, the odd headless browser problems that tend to pop up