### PR TITLE
Add framework for running integration tests with cucumber

### DIFF
--- a/bin/run_tests_in_docker
+++ b/bin/run_tests_in_docker
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-docker-compose run test_case_handling_system
-docker-compose run test_check_legal_aid
+# docker-compose run test_case_handling_system
+# docker-compose run test_check_legal_aid
 docker-compose run behave
 echo "🎉 Tests finished!"

--- a/bin/run_tests_in_docker
+++ b/bin/run_tests_in_docker
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 docker-compose run test_case_handling_system
 docker-compose run test_check_legal_aid
-# docker-compose run behave
+docker-compose run behave
 echo "🎉 Tests finished!"

--- a/bin/run_tests_in_docker
+++ b/bin/run_tests_in_docker
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# docker-compose run test_case_handling_system
-# docker-compose run test_check_legal_aid
-docker-compose run behave
+docker-compose run test_case_handling_system
+docker-compose run test_check_legal_aid
+# docker-compose run behave
 echo "🎉 Tests finished!"

--- a/bin/run_tests_in_docker
+++ b/bin/run_tests_in_docker
@@ -1,4 +1,5 @@
 #!/bin/bash -e
 docker-compose run test_case_handling_system
 docker-compose run test_check_legal_aid
+docker-compose run behave
 echo "🎉 Tests finished!"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -118,3 +118,7 @@ services:
     environment:
       CLA_PUBLIC_URL: http://cla_public
       HEADLESS: "true"
+
+  behave:
+    build:
+      context: tests/behave

--- a/tests/behave/Dockerfile
+++ b/tests/behave/Dockerfile
@@ -1,0 +1,18 @@
+FROM selenium/standalone-firefox
+
+# Install pip
+USER root
+RUN apt-get -qqy update && apt-get -qqy install python3-pip
+
+RUN touch geckodriver.log
+RUN chown seluser:seluser geckodriver.log
+
+# Install requirements
+USER seluser
+COPY requirements.txt ./
+RUN pip3 install --user -r requirements.txt
+
+COPY . .
+RUN which python3
+
+CMD ["/usr/bin/python3", "-m", "behave"]

--- a/tests/behave/features/environment.py
+++ b/tests/behave/features/environment.py
@@ -1,0 +1,11 @@
+from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
+
+
+def before_feature(context, feature):
+    options = Options()
+    options.headless = True
+    context.driver = webdriver.Firefox(options=options)
+
+def after_feature(context, feature):
+    context.driver.quit() 

--- a/tests/behave/features/google.feature
+++ b/tests/behave/features/google.feature
@@ -4,4 +4,4 @@ Feature: Googling
     Scenario: Finding some cheese
         Given I am on the Google search page
         When I search for "Cheese!"
-        Then the page title should start with "cheese"
+        Then the page title should start with "Cheese"

--- a/tests/behave/features/google.feature
+++ b/tests/behave/features/google.feature
@@ -1,0 +1,7 @@
+Feature: Googling
+    Does Googling work?
+
+    Scenario: Finding some cheese
+        Given I am on the Google search page
+        When I search for "Cheese!"
+        Then the page title should start with "cheese"

--- a/tests/behave/features/steps/browsing.py
+++ b/tests/behave/features/steps/browsing.py
@@ -1,0 +1,19 @@
+from behave import *
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+@given("I am on the Google search page")
+def step_impl(context):
+    context.driver.get("http://google.com")
+
+@when("I search for {search_term}")
+def step_impl(context, search_term):
+    element = context.driver.find_element_by_name("q")
+    element.send_keys(search_term)
+    element.submit()
+
+@then('the page title should start with "{title_start}"')
+def step_impl(context, title_start):
+    WebDriverWait(context.driver, 10).until(EC.title_contains(title_start))
+    print("Page title is {title}".format(title=context.driver.title))

--- a/tests/behave/requirements.txt
+++ b/tests/behave/requirements.txt
@@ -1,0 +1,6 @@
+behave==1.2.6
+parse==1.12.0
+parse-type==0.4.2
+selenium
+six==1.12.0
+urllib3==1.24.1


### PR DESCRIPTION
## What does this pull request do?

Adds a `docker-compose run behave` test step which kicks off cucumber with a Python backend. The intention is to write future integration tests with cucumber.

## Any other changes that would benefit highlighting?

No changes to the original branch, I rebased to put it on top of `origin/master`.