### PR TITLE
LGA-709 - Use .page-title class when checking page title on the page

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       HOST_NAME: "0.0.0.0"
       SECRET_KEY: CHANGE_ME
       BACKEND_BASE_URI: http://cla-backend:80
-      CLA_ENV: local
+      CLA_ENV: dev
       ZENDESK_API_USERNAME: ""
       ZENDESK_API_TOKEN: ""
       SMTP_HOST: ""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
       HOST_NAME: "0.0.0.0"
       SECRET_KEY: CHANGE_ME
       BACKEND_BASE_URI: http://cla-backend:80
+      CLA_ENV: local
       ZENDESK_API_USERNAME: ""
       ZENDESK_API_TOKEN: ""
       SMTP_HOST: ""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
 
   # applications
   cla_public:
-    image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:master
+    image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:feature-LGA-709_add-page-title-class
     ports:
       - target: 80
         published: 5000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
 
   # applications
   cla_public:
-    image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:feature-LGA-709_add-page-title-class
+    image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:master
     ports:
       - target: 80
         published: 5000

--- a/tests/check-legal-aid/test/commands/aboutSetAllToNo.js
+++ b/tests/check-legal-aid/test/commands/aboutSetAllToNo.js
@@ -14,7 +14,7 @@ exports.command = function(shouldSubmitForm, options, callback) {
 
     client
       .ensureCorrectPage('#have_partner-0', '/about', {
-        'h1': 'About you'
+        'h1.page-title': 'About you'
       })
       .setYesNoFields(ABOUT_YOU_QUESTIONS, 0, function() {
         console.log('     • Setting all values to ‘No’');

--- a/tests/check-legal-aid/test/commands/aboutSetAllToYes.js
+++ b/tests/check-legal-aid/test/commands/aboutSetAllToYes.js
@@ -11,7 +11,7 @@ exports.command = function(shouldSubmitForm, callback) {
 
     client
       .ensureCorrectPage('#have_partner-0', '/about', {
-        'h1': 'About you'
+        'h1.page-title': 'About you'
       })
       .setYesNoFields(ABOUT_YOU_QUESTIONS, 1, function() {
         console.log('     • Setting all values to ‘Yes’');

--- a/tests/check-legal-aid/test/commands/confirmReviewPage.js
+++ b/tests/check-legal-aid/test/commands/confirmReviewPage.js
@@ -10,7 +10,7 @@ exports.command = function(shouldSubmitForm, callback) {
 
     client
       .ensureCorrectPage('.answers-summary', '/review', {
-        'h1': 'Review your answers'
+        'h1.page-title': 'Review your answers'
       })
       .conditionalFormSubmit(true)
     ;

--- a/tests/check-legal-aid/test/commands/scopeDiagnosis.js
+++ b/tests/check-legal-aid/test/commands/scopeDiagnosis.js
@@ -10,7 +10,7 @@ exports.command = function(scenario, callback) {
 
     client
       .ensureCorrectPage('body.js-enabled', '/scope/diagnosis', {
-        'h1': 'Choose the area you most need help with'
+        'h1.page-title': 'Choose the area you most need help with'
       })
       .useXpath()
     ;

--- a/tests/check-legal-aid/test/specs/404-page.js
+++ b/tests/check-legal-aid/test/specs/404-page.js
@@ -7,7 +7,7 @@ module.exports = {
       .init(client.launch_url + '/notfound')
       .maximizeWindow()
       .ensureCorrectPage('body', '/notfound', {
-        'h1': 'Sorry, this page doesn’t exist'
+        'h1.page-title': 'Sorry, this page doesn’t exist'
       })
       .end()
     ;

--- a/tests/check-legal-aid/test/specs/benefits-page.js
+++ b/tests/check-legal-aid/test/specs/benefits-page.js
@@ -27,7 +27,7 @@ module.exports = {
 
   Benefits: function(client) {
     client.ensureCorrectPage("#benefits-0", "/benefits", {
-      h1: "Your benefits",
+      "h1.page-title": "Your benefits",
       "fieldset legend": "Which benefits do you receive?"
     });
   },
@@ -35,7 +35,7 @@ module.exports = {
   "Context-dependent text and headline for partner": function(client) {
     client.assert
       .doesNotContainText(
-        "h1",
+        "h1.page-title",
         "You and your partner’s benefits",
         "  - Title is correct"
       )
@@ -57,7 +57,7 @@ module.exports = {
       })
       .waitForElementVisible("#benefits-0", 5000, "    - On /benefits page")
       .assert.containsText(
-        "h1",
+        "h1.page-title",
         "You and your partner’s benefits",
         "    - Title is correct"
       )

--- a/tests/check-legal-aid/test/specs/confirmation-page.js
+++ b/tests/check-legal-aid/test/specs/confirmation-page.js
@@ -29,7 +29,7 @@ var checkCallbackTime = function(client, then, time) {
       console.log("     ⟡ Form submitted");
     })
     .ensureCorrectPage("header.confirmation", "/result/confirmation", {
-      h1: "We will call you back",
+      "h1.page-title": "We will call you back",
       ".main-content": formattedCallbackTime
     })
     .checkFlashMessage();

--- a/tests/check-legal-aid/test/specs/contact-page.js
+++ b/tests/check-legal-aid/test/specs/contact-page.js
@@ -41,7 +41,7 @@ module.exports = {
         "    - Confirmation block exists"
       )
       .assert.containsText(
-        "h1",
+        "h1.page-title",
         "Your details have been submitted",
         "    - Confirmation title exists"
       );

--- a/tests/check-legal-aid/test/specs/currency-formatting.js
+++ b/tests/check-legal-aid/test/specs/currency-formatting.js
@@ -45,7 +45,7 @@ module.exports = {
 
   "Property page": function(client) {
     client.ensureCorrectPage("#properties-0-is_main_home-0", "/property", {
-      h1: "Your property"
+      "h1.page-title": "Your property"
     });
   },
 

--- a/tests/check-legal-aid/test/specs/eligible-page.js
+++ b/tests/check-legal-aid/test/specs/eligible-page.js
@@ -26,7 +26,7 @@ module.exports = {
   Benefits: function(client) {
     client
       .ensureCorrectPage("#benefits-0", "/benefits", {
-        h1: "Your benefits",
+        "h1.page-title": "Your benefits",
         "fieldset legend": "Which benefits do you receive?"
       })
       .click('input[value="income_support"]', function() {
@@ -43,7 +43,7 @@ module.exports = {
 
   "Eligible page (request callback)": function(client) {
     client.ensureCorrectPage(".contact-form", "/result/eligible", {
-      h1: "Contact Civil Legal Advice"
+      "h1.page-title": "Contact Civil Legal Advice"
     });
   },
 

--- a/tests/check-legal-aid/test/specs/face-to-face-page.js
+++ b/tests/check-legal-aid/test/specs/face-to-face-page.js
@@ -18,7 +18,7 @@ module.exports = {
         ".legal-adviser-search",
         "/scope/refer/legal-adviser",
         {
-          h1: "A legal adviser may be able to help you"
+          "h1.page-title": "A legal adviser may be able to help you"
         }
       )
       .checkFlashMessage();

--- a/tests/check-legal-aid/test/specs/income-page.js
+++ b/tests/check-legal-aid/test/specs/income-page.js
@@ -38,7 +38,7 @@ module.exports = {
       'input[name="your_income-other_income-per_interval_value"]',
       "/income",
       {
-        h1: "Your money"
+        "h1.page-title": "Your money"
       }
     );
   },
@@ -100,7 +100,7 @@ module.exports = {
       .setYesNoFields("partner_is_employed", 1)
       .conditionalFormSubmit(true)
       .assert.containsText(
-        "h1",
+        "h1.page-title",
         "You and your partner’s money",
         "    - Page heading is correct"
       )

--- a/tests/check-legal-aid/test/specs/other-benefits-page.js
+++ b/tests/check-legal-aid/test/specs/other-benefits-page.js
@@ -30,7 +30,7 @@ module.exports = {
 
   "Additional Benefits page": function(client) {
     client.ensureCorrectPage("#other_benefits-0", "/additional-benefits", {
-      h1: "Your additional benefits"
+      "h1.page-title": "Your additional benefits"
     });
   },
 
@@ -50,7 +50,7 @@ module.exports = {
       .waitForElementVisible("#benefits-0", 5000, "  - Back to /benefits")
       .conditionalFormSubmit(true)
       .assert.containsText(
-        "h1",
+        "h1.page-title",
         "You and your partner’s additional benefits",
         "  - Page heading is correct (includes partner)"
       );

--- a/tests/check-legal-aid/test/specs/outgoings-page.js
+++ b/tests/check-legal-aid/test/specs/outgoings-page.js
@@ -35,7 +35,7 @@ module.exports = {
         'input[name="your_income-other_income-per_interval_value"]',
         "/income",
         {
-          h1: "Your money coming in"
+          "h1.page-title": "Your money coming in"
         }
       )
       .setValue('input[name="your_income-maintenance-per_interval_value"]', 0)
@@ -49,7 +49,7 @@ module.exports = {
       'input[name="income_contribution"]',
       "/outgoings",
       {
-        h1: "Your outgoings"
+        "h1.page-title": "Your outgoings"
       }
     );
   },
@@ -123,7 +123,7 @@ module.exports = {
       .conditionalFormSubmit(true)
       .fillInIncome(true, true, true)
       .assert.containsText(
-        "h1",
+        "h1.page-title",
         "You and your partner’s outgoings",
         "  - Has correct heading"
       )

--- a/tests/check-legal-aid/test/specs/property-page.js
+++ b/tests/check-legal-aid/test/specs/property-page.js
@@ -28,7 +28,7 @@ module.exports = {
 
   "Property page": function(client) {
     client.ensureCorrectPage("#properties-0-is_main_home-0", "/property", {
-      h1: "Your property"
+      "h1.page-title": "Your property"
     });
   },
 
@@ -44,7 +44,7 @@ module.exports = {
       )
       .conditionalFormSubmit(true)
       .ensureCorrectPage("#properties-0-is_main_home-0", "/property", {
-        h1: "You and your partner’s property",
+        "h1.page-title": "You and your partner’s property",
         body:
           "Please tell us about any property owned by you, your partner or both of you"
       });

--- a/tests/check-legal-aid/test/specs/savings-page.js
+++ b/tests/check-legal-aid/test/specs/savings-page.js
@@ -33,7 +33,7 @@ module.exports = {
 
   "Savings page": function(client) {
     client.ensureCorrectPage('input[name="savings"]', "/savings", {
-      h1: "Your savings"
+      "h1.page-title": "Your savings"
     });
   },
 
@@ -53,7 +53,7 @@ module.exports = {
       )
       .conditionalFormSubmit(true)
       .ensureCorrectPage("body.js-enabled", "/savings", {
-        h1: "You and your partner’s savings",
+        "h1.page-title": "You and your partner’s savings",
         body:
           "Any cash, savings or investments held in your name, your partner’s name or both your names"
       });

--- a/tests/check-legal-aid/test/specs/static-pages.js
+++ b/tests/check-legal-aid/test/specs/static-pages.js
@@ -29,7 +29,7 @@ module.exports = {
         })
         .useCss()
         .ensureCorrectPage('body.js-enabled', item.url, {
-          'h1': item.headline
+          'h1.page-title': item.headline
         })
       ;
     });


### PR DESCRIPTION
## What does this pull request do?

Use .page-title class when checking page title on the page as the page now contains multiple `<h1>` tags which causes the end-to-end test to fail

## Any other changes that would benefit highlighting?

Related to https://github.com/ministryofjustice/cla_public/pull/856
