### PR TITLE
Make tests use FALA container rather than live staging

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -125,4 +125,17 @@ services:
       context: tests/behave
     environment:
       CLA_FRONTEND_URL: "http://cla_frontend/"
-      FALA_URL: "https://laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io"
+      FALA_URL: "http://fala:8000"
+    depends_on:
+      - fala
+  fala:
+    image: ${FALA_IMAGE:-926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala-webapp:master}
+    ports:
+      - target: 8000
+        published: 8002
+        protocol: tcp
+        mode: host
+    environment:
+      SECRET_KEY: CHANGE_ME
+      LAALAA_API_HOST: "https://prod.laalaa.dsd.io"
+      ALLOWED_HOSTS: "*"


### PR DESCRIPTION
## What does this pull request do?

Makes the end to end tests use a local FALA container that is configured to use production LAALAA as its endpoint, to ensure that the provider data our tests expect is present (although I feel like it should really use a local LAALAA and the tests should expect standard data provided in fixtures or a seeding script)

## Any other changes that would benefit highlighting?

Intentionally left blank.
