### PR TITLE
Set test and teardown steps to always run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,15 @@ jobs:
       - run:
           name: Run cucumber tests
           command: bin/run_cucumber_in_docker
+          when: always
       - run:
           name: Run javascript tests
           command: bin/run_tests_in_docker
+          when: always
       - run:
           name: Clean up running containers
           command: bin/stop
+          when: always
 workflows:
   version: 2
   run-tests:


### PR DESCRIPTION
## What does this pull request do?

This overrides the default `on_success`, which prevents the step from
being run if a previous step has failed. In this case, this was causing
a failure in the cucumber tests to suppress the js tests from running at
all, and also presumably blocking the cleanup step after failures

## Any other changes that would benefit highlighting?

Intentionally left blank.
