### PR TITLE
Update footer links to remove feedback and add Online Safety and contact

### DIFF
--- a/tests/check-legal-aid/test/specs/static-pages.js
+++ b/tests/check-legal-aid/test/specs/static-pages.js
@@ -12,8 +12,12 @@ var STATIC_PAGES = [
     headline: "Terms and conditions and privacy"
   },
   {
-    url: "/feedback",
-    headline: "Your feedback"
+    url: "/online-safety",
+    headline: "Staying safe online"
+  },
+  {
+    url: "/reasons-for-contacting",
+    headline: "Before you contact Civil Legal Advice"
   }
 ];
 


### PR DESCRIPTION
## What does this pull request do?

Updated to reflect that the /feedback link is no longer in the footer
Added /online-safety and /reasons-for-contacting links to the footer to reflect CLA live

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
